### PR TITLE
test(mongo): refactored in memory mongo db to start only once per JVM

### DIFF
--- a/core/src/itest/scala/com/spacecorpshandbook/ticker/core/io/db/TickerDatabaseSetup.scala
+++ b/core/src/itest/scala/com/spacecorpshandbook/ticker/core/io/db/TickerDatabaseSetup.scala
@@ -1,74 +1,78 @@
 package com.spacecorpshandbook.ticker.core.io.db
 
-import com.spacecorpshandbook.ticker.core.constant.Database._
+import com.spacecorpshandbook.ticker.core.constant.Database.STOCK_TICKER_COLLECTION
 import de.flapdoodle.embed.mongo.config.{IMongodConfig, MongodConfigBuilder, Net}
 import de.flapdoodle.embed.mongo.distribution.Version
 import de.flapdoodle.embed.mongo.{MongodExecutable, MongodProcess, MongodStarter}
 import de.flapdoodle.embed.process.runtime.Network
-import org.mongodb.scala.{MongoCollection, MongoDatabase}
 import org.mongodb.scala.bson.collection.immutable.Document
+import org.mongodb.scala.{MongoCollection, MongoDatabase}
 
-import scala.concurrent.Future
 import scala.io.Source
 
-trait TickerDatabaseSetup {
+object TickerDatabaseSetup {
 
   var mongodExecutable: MongodExecutable = _
-  var mongoDatabase: MongoDatabase = _
   var mongoD: MongodProcess = _
   var persistence: Persistence = _
-  var initDoneFuture: Future[_] = _
-  var collection: MongoCollection[Document] = _
   val starter: MongodStarter = MongodStarter.getDefaultInstance
+
+  try {
+
+    val mongoSystemConfig: MongoSystemConfig = new MongoSystemConfig
+
+    val mongodConfig: IMongodConfig = new MongodConfigBuilder()
+      .version(Version.Main.PRODUCTION)
+      .net(new Net(mongoSystemConfig.getDatabaseHost, mongoSystemConfig.getDatabasePort, Network.localhostIsIPv6()))
+      .build
+
+    mongodExecutable = starter.prepare(mongodConfig)
+    mongoD = mongodExecutable.start()
+  }
+  catch {
+
+    case ex: Exception =>
+
+      System.err.println(s"""Error setting up database for test: ${ex.toString}""")
+
+      if (mongoD != null) {
+
+        mongoD.stop()
+      }
+
+      if (mongodExecutable != null) {
+
+        mongodExecutable.stop()
+      }
+  }
+
 
   def databaseSetup = {
 
-    try {
-      val mongodConfig: IMongodConfig = new MongodConfigBuilder()
-        .version(Version.Main.PRODUCTION)
-        .net(new Net(MongoConnection.host, MongoConnection.port, Network.localhostIsIPv6()))
-        .build
+    val mongoDatabase: MongoDatabase = MongoConnection.getDefaultDatabase
 
-      mongodExecutable = starter.prepare(mongodConfig)
-      mongoD = mongodExecutable.start()
-      mongoDatabase = MongoConnection.getDefaultDatabase
+    var collection: MongoCollection[Document] = mongoDatabase.getCollection(STOCK_TICKER_COLLECTION)
 
-      collection = mongoDatabase.getCollection(STOCK_TICKER_COLLECTION)
+    val tickerDataStream = getClass.getClassLoader.getResourceAsStream("ticker-data.json")
+    val linesOfJson = Source.fromInputStream(tickerDataStream).getLines
+    var docsToInsert: Seq[Document] = Seq()
 
-      val tickerDataStream = getClass.getClassLoader.getResourceAsStream("ticker-data.json")
-      val linesOfJson = Source.fromInputStream(tickerDataStream).getLines
-      var docsToInsert: Seq[Document] = Seq()
 
-      for (jsonLine <- linesOfJson) {
-        docsToInsert = docsToInsert :+ Document(jsonLine)
-      }
+    for (jsonLine <- linesOfJson) {
 
-      initDoneFuture = collection.insertMany(docsToInsert).toFuture()
+      docsToInsert = docsToInsert :+ Document(jsonLine)
     }
-    catch {
 
-      case ex: Exception =>
+    val initDoneFuture = collection.insertMany(docsToInsert).toFuture()
 
-        System.err.println(ex.toString)
-
-        if (mongoD != null) {
-
-          mongoD.stop()
-        }
-
-        if (mongodExecutable != null) {
-
-          mongodExecutable.stop()
-        }
-    }
+    initDoneFuture
   }
 
   def databaseCleanup = {
 
-    if (mongodExecutable != null) {
+    val mongoDatabase: MongoDatabase = MongoConnection.getDefaultDatabase
+    var collection: MongoCollection[Document] = mongoDatabase.getCollection(STOCK_TICKER_COLLECTION)
 
-      mongoD.stop()
-      mongodExecutable.stop()
-    }
+    collection.drop().toFuture()
   }
 }

--- a/core/src/itest/scala/com/spacecorpshandbook/ticker/core/io/db/TickerPersistenceTest.scala
+++ b/core/src/itest/scala/com/spacecorpshandbook/ticker/core/io/db/TickerPersistenceTest.scala
@@ -3,33 +3,40 @@ package com.spacecorpshandbook.ticker.core.io.db
 import java.time.LocalDate
 
 import com.spacecorpshandbook.ticker.core.model.Ticker
+import org.mongodb.scala.MongoDatabase
 import org.scalatest.{AsyncFlatSpec, BeforeAndAfter, BeforeAndAfterAll, Matchers}
+
+import scala.concurrent.Future
 
 class TickerPersistenceTest extends AsyncFlatSpec
   with Matchers
   with BeforeAndAfter
-  with BeforeAndAfterAll
-  with TickerDatabaseSetup {
+  with BeforeAndAfterAll {
 
   val ticker: Ticker = new Ticker
+  var persistence : TickerPersistence = _
+  var initDoneFuture: Future[_] = _
 
   override def beforeAll() {
 
     super.beforeAll()
 
-    databaseSetup
+    initDoneFuture = TickerDatabaseSetup.databaseSetup
   }
 
   override def afterAll() {
 
-    databaseCleanup
-
     super.afterAll()
+
+    TickerDatabaseSetup.databaseCleanup
   }
+
 
   before {
 
-    persistence = TickerPersistence(mongoDatabase)
+    val mongoDatabase: MongoDatabase = MongoConnection.getDefaultDatabase
+
+    persistence = new TickerPersistence(mongoDatabase)
   }
 
   behavior of "database search"
@@ -106,7 +113,6 @@ class TickerPersistenceTest extends AsyncFlatSpec
       assert(tickers.isEmpty)
     }
   }
-
 
   it should "eventually return no results when ticker symbol doesn't exist in the database" in {
 

--- a/core/src/main/scala/com/spacecorpshandbook/ticker/core/io/db/MongoConnection.scala
+++ b/core/src/main/scala/com/spacecorpshandbook/ticker/core/io/db/MongoConnection.scala
@@ -4,103 +4,16 @@ import org.mongodb.scala.{MongoClient, MongoDatabase}
 
 object MongoConnection {
 
-  var databaseName: String = _
+  private val mongoSystemConfig: MongoSystemConfig = new MongoSystemConfig
 
-  var port: Int = _
+  private val connectionUrl = mongoSystemConfig.composeConnectionUrl
 
-  var host: String = _
-
-  private val connectionUrl = composeConnectionUrl
-
-  System.out.println(connectionUrl)
+  System.out.println(s"Mongo Connection String: $connectionUrl")
 
   val mongoClient: MongoClient = MongoClient(connectionUrl)
 
-  def composeConnectionUrl = {
-
-    val mongoSystemConfig: MongoSystemConfig = new MongoSystemConfig
-
-    databaseName = mongoSystemConfig.getDatabaseName
-    port = mongoSystemConfig.getDatabasePort
-    host = mongoSystemConfig.getDatabaseHost
-    val userName = mongoSystemConfig.getUserName
-    val password = mongoSystemConfig.getPassword
-
-    (userName, password) match {
-
-      case (Some(aUserName), Some(aPassword)) => s"mongodb://$aUserName:$aPassword@$host:$port/$databaseName"
-      case _ => s"mongodb://$host:$port/$databaseName"
-    }
-  }
-
   def getDefaultDatabase: MongoDatabase = {
 
-    mongoClient.getDatabase(databaseName)
+    mongoClient.getDatabase(mongoSystemConfig.getDatabaseName)
   }
-}
-
-class MongoSystemConfig {
-
-  def getDatabaseHost: String = {
-
-    getStringEnvValue(MongoSystemConfig.TICKER_DB_HOST_ENV_VAR) match {
-      case Some(value) => value
-      case None => "localhost"
-    }
-  }
-
-  def getDatabaseName: String = {
-
-    getStringEnvValue(MongoSystemConfig.TICKER_DB_NAME_ENV_VAR) match {
-      case Some(value) => value
-      case None => "testStockData"
-    }
-  }
-
-  def getDatabasePort: Int = {
-
-    val envHold = System.getenv(MongoSystemConfig.TICKER_DB_PORT_ENV_VAR)
-
-    if (isNonNullOrEmpty(envHold)) {
-
-      envHold.toInt
-    } else {
-
-      12345
-    }
-  }
-
-  def getPassword: Option[String] = {
-
-    getStringEnvValue(MongoSystemConfig.TICKER_DB_PASSWORD_ENV_VAR)
-  }
-
-  def getUserName: Option[String] = {
-
-    getStringEnvValue(MongoSystemConfig.TICKER_DB_USER_NAME_ENV_VAR)
-  }
-
-  private def getStringEnvValue(envVarName: String): Option[String] = {
-
-    val envHold = System.getenv(envVarName)
-
-    if (isNonNullOrEmpty(envHold)) {
-
-      Some(envHold)
-    } else {
-
-      None
-    }
-  }
-
-  private def isNonNullOrEmpty(value: String) = value != null && value.nonEmpty
-}
-
-object MongoSystemConfig {
-
-  val TICKER_DB_HOST_ENV_VAR = "TICKER_DB_HOST"
-  val TICKER_DB_NAME_ENV_VAR = "TICKER_DB_NAME"
-  val TICKER_DB_PASSWORD_ENV_VAR = "TICKER_DB_PASSWORD"
-  val TICKER_DB_PORT_ENV_VAR = "TICKER_DB_PORT"
-  val TICKER_DB_USER_NAME_ENV_VAR = "TICKER_DB_USER"
 }

--- a/core/src/main/scala/com/spacecorpshandbook/ticker/core/io/db/MongoSystemConfig.scala
+++ b/core/src/main/scala/com/spacecorpshandbook/ticker/core/io/db/MongoSystemConfig.scala
@@ -1,0 +1,84 @@
+package com.spacecorpshandbook.ticker.core.io.db
+
+class MongoSystemConfig {
+
+  def getDatabaseHost: String = {
+
+    getStringEnvValue(MongoSystemConfig.TICKER_DB_HOST_ENV_VAR) match {
+      case Some(value) => value
+      case None => "localhost"
+    }
+  }
+
+  def getDatabaseName: String = {
+
+    getStringEnvValue(MongoSystemConfig.TICKER_DB_NAME_ENV_VAR) match {
+      case Some(value) => value
+      case None => "testStockData"
+    }
+  }
+
+  def getDatabasePort: Int = {
+
+    val envHold = System.getenv(MongoSystemConfig.TICKER_DB_PORT_ENV_VAR)
+
+    if (isNonNullOrEmpty(envHold)) {
+
+      envHold.toInt
+    } else {
+
+      12345
+    }
+  }
+
+  def getPassword: Option[String] = {
+
+    getStringEnvValue(MongoSystemConfig.TICKER_DB_PASSWORD_ENV_VAR)
+  }
+
+  def getUserName: Option[String] = {
+
+    getStringEnvValue(MongoSystemConfig.TICKER_DB_USER_NAME_ENV_VAR)
+  }
+
+  private def getStringEnvValue(envVarName: String): Option[String] = {
+
+    val envHold = System.getenv(envVarName)
+
+    if (isNonNullOrEmpty(envHold)) {
+
+      Some(envHold)
+    } else {
+
+      None
+    }
+  }
+
+  def composeConnectionUrl = {
+
+    val mongoSystemConfig: MongoSystemConfig = new MongoSystemConfig
+
+    val databaseName = mongoSystemConfig.getDatabaseName
+    val port = mongoSystemConfig.getDatabasePort
+    val host = mongoSystemConfig.getDatabaseHost
+    val userName = mongoSystemConfig.getUserName
+    val password = mongoSystemConfig.getPassword
+
+    (userName, password) match {
+
+      case (Some(aUserName), Some(aPassword)) => s"mongodb://$aUserName:$aPassword@$host:$port/$databaseName"
+      case _ => s"mongodb://$host:$port/$databaseName"
+    }
+  }
+
+  private def isNonNullOrEmpty(value: String) = value != null && value.nonEmpty
+}
+
+object MongoSystemConfig {
+
+  val TICKER_DB_HOST_ENV_VAR = "TICKER_DB_HOST"
+  val TICKER_DB_NAME_ENV_VAR = "TICKER_DB_NAME"
+  val TICKER_DB_PASSWORD_ENV_VAR = "TICKER_DB_PASSWORD"
+  val TICKER_DB_PORT_ENV_VAR = "TICKER_DB_PORT"
+  val TICKER_DB_USER_NAME_ENV_VAR = "TICKER_DB_USER"
+}

--- a/core/src/test/scala/com/spacecorpshandbook/ticker/core/io/db/MongoSystemConfigTest.scala
+++ b/core/src/test/scala/com/spacecorpshandbook/ticker/core/io/db/MongoSystemConfigTest.scala
@@ -4,7 +4,7 @@ import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.scalatest.{FlatSpec, Matchers}
 
-class MongoConnectionITest extends FlatSpec
+class MongoSystemConfigTest extends FlatSpec
   with Matchers {
 
   val _envVars: EnvironmentVariables = new EnvironmentVariables
@@ -14,7 +14,7 @@ class MongoConnectionITest extends FlatSpec
 
   val mongoSystemConfig = new MongoSystemConfig
 
-  behavior of "A MongoConnection"
+  behavior of "A MongoSystemConfig"
 
   it should "default the database name when the environment variable isn't set" in {
 
@@ -120,7 +120,7 @@ class MongoConnectionITest extends FlatSpec
 
     val noCredentialsMongoUrlRegEx = """mongodb\:\/\/[a-zA-Z]+\:[0-9]+\/[\w]+"""
 
-    MongoConnection.composeConnectionUrl should fullyMatch regex noCredentialsMongoUrlRegEx
+    mongoSystemConfig.composeConnectionUrl should fullyMatch regex noCredentialsMongoUrlRegEx
   }
 
   it should "set the mongo connection string correctly when there are credentials" in {
@@ -133,6 +133,6 @@ class MongoConnectionITest extends FlatSpec
 
     val withCredentialsMongoUrlRegEx = s"mongodb\\:\\/\\/$userName\\:$passowrd@[a-zA-Z]+\\:[0-9]+\\/[\\w]+".r
 
-    MongoConnection.composeConnectionUrl should fullyMatch regex withCredentialsMongoUrlRegEx
+    mongoSystemConfig.composeConnectionUrl should fullyMatch regex withCredentialsMongoUrlRegEx
   }
 }


### PR DESCRIPTION
Starting and stopping the in memory database inbetween tests causes odd connection isues on mac osx and broken pipe errors
on linux. Refactored the test code so that the start of the database is done once and each test cleans up the data
collections between scenarios.